### PR TITLE
fix: fall back Notion book date to updateTime when finishTime is missing

### DIFF
--- a/src/weread2notion/cli.py
+++ b/src/weread2notion/cli.py
@@ -209,6 +209,7 @@ def get_read_info(bookId):
         "readingTime": book.get("recordReadingTime") or 0,
         "readingProgress": reading_progress,
         "finishedDate": finish_time,
+        "updateDate": update_time,
     }
 
 
@@ -323,7 +324,7 @@ def insert_to_notion(bookName, bookId, cover, sort, author, isbn, rating, catego
         raw_properties["阅读进度"] = readingProgress
         if "finishedDate" in read_info:
             raw_properties["时间"] = datetime.utcfromtimestamp(
-                read_info.get("finishedDate")
+                read_info.get("finishedDate") or read_info.get("updateDate")
             ).strftime(
                 "%Y-%m-%d %H:%M:%S"
             )


### PR DESCRIPTION
## Summary
- Fix Notion `时间` falling back to `1970-01-01` for books still in progress
- When `finishTime` is missing or `0`, use the book's `updateTime` from WeRead progress API instead

<img width="2442" height="1614" alt="PixPin_2026-07-20_17-07-07" src="https://github.com/user-attachments/assets/ec57345b-111e-4c64-a974-22556fd33565" />


## Fixed
- When `finishTime` is missing or `0`, use the book's `updateTime` from WeRead progress API instead
<img width="2342" height="1582" alt="PixPin_2026-07-20_17-07-54" src="https://github.com/user-attachments/assets/919f3138-d147-47ec-9919-41b861937730" />

